### PR TITLE
Feature/frontend crud incidentes

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -24,7 +24,7 @@ export const login = async (req, res) => {
       { expiresIn: '1h' }
     );
 
-    res.json({ token, usuario: { id: usuario.id, email: usuario.email } });
+    res.json({ token, usuario: { id: usuario.id, email: usuario.email, name: usuario.nombre, role: usuario.rol } });
   } catch (error) {
     console.error(error);
     res.status(500).json({ message: 'Error en el servidor' });

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@mui/material": "^7.0.2",
         "@reduxjs/toolkit": "^2.7.0",
         "axios": "^1.9.0",
+        "dayjs": "^1.11.13",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-redux": "^9.2.0",
@@ -2018,6 +2019,11 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="
     },
     "node_modules/debug": {
       "version": "4.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@mui/material": "^7.0.2",
     "@reduxjs/toolkit": "^2.7.0",
     "axios": "^1.9.0",
+    "dayjs": "^1.11.13",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-redux": "^9.2.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,13 +2,28 @@ import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Login from './features/auth/Login';
 import Dashboard from './features/dashboard/Dashboard';
+import Incidentes from './features/incidentes/Incidentes';
+import { Typography } from '@mui/material';
+
+// Componente de inicio del dashboard (ruta index)
+const DashboardHome = () => (
+  <div>
+    <Typography variant="h4">Panel de Control</Typography>
+    <Typography>Bienvenido al inicio del dashboard</Typography>
+  </div>
+);
 
 const App = () => {
   return (
     <Router>
       <Routes>
         <Route path="/" element={<Login />} />
-        <Route path="/dashboard" element={<Dashboard />} />
+
+        <Route path="/dashboard" element={<Dashboard />}>
+          <Route index element={<DashboardHome />} />
+          <Route path="incidentes" element={<Incidentes />} />
+          {/* Puedes agregar más subrutas aquí, como perfil o configuración */}
+        </Route>
       </Routes>
     </Router>
   );

--- a/frontend/src/features/auth/Login.jsx
+++ b/frontend/src/features/auth/Login.jsx
@@ -1,7 +1,6 @@
 // features/auth/Login.jsx
 import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { logout } from './authSlice';
 import { useNavigate } from 'react-router-dom';
 import { loginUser } from './authThunks';
 import {
@@ -17,7 +16,7 @@ import {
 
 const Login = () => {
   const dispatch = useDispatch();
-  const { isAuthenticated, user, loading, error } = useSelector((state) => state.auth);
+  const { isAuthenticated, loading, error } = useSelector((state) => state.auth);
 
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
@@ -26,10 +25,6 @@ const Login = () => {
     if (username.trim() && password.trim()) {
       dispatch(loginUser({ email: username, password }));
     }
-  };
-
-  const handleLogout = () => {
-    dispatch(logout());
   };
 
   const navigate = useNavigate();

--- a/frontend/src/features/auth/authThunks.js
+++ b/frontend/src/features/auth/authThunks.js
@@ -13,7 +13,6 @@ export const loginUser = createAsyncThunk(
       const { token, usuario } = response.data;
       localStorage.setItem('user', JSON.stringify(usuario));
       localStorage.setItem('authToken', token);
-      console.log(usuario);
 
       return { user: usuario, token };
     } catch (error) {

--- a/frontend/src/features/dashboard/Dashboard.jsx
+++ b/frontend/src/features/dashboard/Dashboard.jsx
@@ -1,23 +1,14 @@
 // features/dashboard/Dashboard.jsx
-import React from 'react';
+import React , { useEffect } from 'react';
 import {
-  AppBar,
-  Box,
-  Button,
-  CssBaseline,
-  Drawer,
-  IconButton,
-  List,
-  ListItem,
-  ListItemText,
-  Toolbar,
-  Typography,
-  Container,
+  AppBar, Box, Button, CssBaseline, Drawer,
+  IconButton, List, ListItem, ListItemText,
+  Toolbar, Typography
 } from '@mui/material';
 import MenuIcon from '@mui/icons-material/Menu';
 import { useDispatch, useSelector } from 'react-redux';
 import { logout } from '../auth/authSlice';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Outlet } from 'react-router-dom';
 
 const drawerWidth = 240;
 
@@ -27,25 +18,28 @@ const Dashboard = () => {
   const { isAuthenticated, user } = useSelector((state) => state.auth);
   const [mobileOpen, setMobileOpen] = React.useState(false);
 
-  
+  useEffect(() => {
+    if (!isAuthenticated) navigate('/');
+  }, [isAuthenticated, navigate]);
+
   const handleLogout = () => {
-      dispatch(logout());
-      navigate('/');
-    };
-    
-    const handleDrawerToggle = () => {
-        setMobileOpen(!mobileOpen);
-    };
+    dispatch(logout());
+  };
+
+  const handleDrawerToggle = () => {
+    setMobileOpen(!mobileOpen);
+  };
 
   const drawer = (
     <div>
       <Toolbar />
       <List>
-        {['Inicio', 'Perfil', 'Configuración', 'Reportes'].map((text) => (
-          <ListItem button key={text}>
-            <ListItemText primary={text} />
-          </ListItem>
-        ))}
+        <ListItem button onClick={() => navigate('/dashboard')}>
+          <ListItemText primary="Inicio" />
+        </ListItem>
+        <ListItem button onClick={() => navigate('/dashboard/incidentes')}>
+          <ListItemText primary="Incidentes" />
+        </ListItem>
       </List>
     </div>
   );
@@ -53,14 +47,9 @@ const Dashboard = () => {
   return (
     <Box sx={{ display: 'flex' }}>
       <CssBaseline />
-
-      {/* NAVBAR */}
       <AppBar
         position="fixed"
-        sx={{
-          width: { sm: `calc(100% - ${drawerWidth}px)` },
-          ml: { sm: `${drawerWidth}px` },
-        }}
+        sx={{ width: { sm: `calc(100% - ${drawerWidth}px)` }, ml: { sm: `${drawerWidth}px` } }}
       >
         <Toolbar>
           <IconButton
@@ -71,63 +60,36 @@ const Dashboard = () => {
           >
             <MenuIcon />
           </IconButton>
-          <Typography variant="h6" noWrap sx={{ flexGrow: 1 }}>
-            Bienvenido, {user.nombre}
+          <Typography variant="h6" sx={{ flexGrow: 1 }}>
+            Bienvenido, {user?.name || 'Usuario'}
           </Typography>
-          <Button color="inherit" onClick={handleLogout}>
-            Cerrar sesión
-          </Button>
+          <Button color="inherit" onClick={handleLogout}>Cerrar sesión</Button>
         </Toolbar>
       </AppBar>
 
-      {/* SIDEBAR */}
-      <Box
-        component="nav"
-        sx={{ width: { sm: drawerWidth }, flexShrink: { sm: 0 } }}
-        aria-label="sidebar"
-      >
+      {/* Sidebar */}
+      <Box component="nav" sx={{ width: { sm: drawerWidth }, flexShrink: { sm: 0 } }}>
         <Drawer
           variant="temporary"
           open={mobileOpen}
           onClose={handleDrawerToggle}
-          ModalProps={{ keepMounted: true }}
-          sx={{
-            display: { xs: 'block', sm: 'none' },
-            '& .MuiDrawer-paper': { boxSizing: 'border-box', width: drawerWidth },
-          }}
+          sx={{ display: { xs: 'block', sm: 'none' }, '& .MuiDrawer-paper': { width: drawerWidth } }}
         >
           {drawer}
         </Drawer>
         <Drawer
           variant="permanent"
-          sx={{
-            display: { xs: 'none', sm: 'block' },
-            '& .MuiDrawer-paper': { boxSizing: 'border-box', width: drawerWidth },
-          }}
+          sx={{ display: { xs: 'none', sm: 'block' }, '& .MuiDrawer-paper': { width: drawerWidth } }}
           open
         >
           {drawer}
         </Drawer>
       </Box>
 
-      {/* CONTENIDO PRINCIPAL */}
-      <Box
-        component="main"
-        sx={{
-          flexGrow: 1,
-          p: 3,
-          width: { sm: `calc(100% - ${drawerWidth}px)` },
-        }}
-      >
+      {/* Contenido principal */}
+      <Box component="main" sx={{ flexGrow: 1, p: 3, width: { sm: `calc(100% - ${drawerWidth}px)` } }}>
         <Toolbar />
-        <Container maxWidth="md">
-          <Typography variant="h4" gutterBottom>
-            Panel de Control
-          </Typography>
-          <Typography variant="body1">
-            ¡Has iniciado sesión exitosamente! Usa el menú lateral para navegar.
-          </Typography>
-        </Container>
+        <Outlet />
       </Box>
     </Box>
   );

--- a/frontend/src/features/incidentes/Incidentes.jsx
+++ b/frontend/src/features/incidentes/Incidentes.jsx
@@ -1,0 +1,228 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Box,
+  Typography,
+  TextField,
+  IconButton,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  Paper,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  CircularProgress,
+} from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import AddIcon from '@mui/icons-material/Add';
+import axiosInstance from '../../api/axiosInstance';
+
+const Incidentes = () => {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [incidentes, setIncidentes] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [selected, setSelected] = useState(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [dialogMode, setDialogMode] = useState('view');
+
+  const fetchIncidentes = async () => {
+    try {
+      const response = await axiosInstance.get('/incidentes');
+      setIncidentes(response.data);
+    } catch (error) {
+      console.error('Error al obtener incidentes:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchIncidentes();
+  }, []);
+
+  const handleOpenDialog = (mode, incidente = null) => {
+    setDialogMode(mode);
+    setSelected(incidente);
+    setDialogOpen(true);
+  };
+
+  const handleCloseDialog = () => {
+    setDialogOpen(false);
+    setSelected(null);
+  };
+
+  const filtered = incidentes.filter((i) =>
+    i.codigo.toLowerCase().includes(searchTerm.toLowerCase())
+  );
+
+  return (
+    <Box>
+      <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
+        <Typography variant="h4">Incidentes</Typography>
+        <Button
+          variant="contained"
+          startIcon={<AddIcon />}
+          onClick={() => handleOpenDialog('create', {
+            codigo: '',
+            fecha: '',
+            hora: '',
+            ubicacion: '',
+            tipo_incidente: '',
+            descripcion: '',
+            estado: '',
+            creado_por: '',
+          })}
+        >
+          Nuevo Incidente
+        </Button>
+      </Box>
+
+      <TextField
+        fullWidth
+        label="Buscar por código"
+        variant="outlined"
+        margin="normal"
+        value={searchTerm}
+        onChange={(e) => setSearchTerm(e.target.value)}
+      />
+
+      {loading ? (
+        <Box display="flex" justifyContent="center" mt={4}>
+          <CircularProgress />
+        </Box>
+      ) : (
+        <Paper sx={{ mt: 2 }}>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>Código</TableCell>
+                <TableCell>Fecha</TableCell>
+                <TableCell>Ubicación</TableCell>
+                <TableCell>Tipo</TableCell>
+                <TableCell>Estado</TableCell>
+                <TableCell align="center">Acciones</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {filtered.map((i) => (
+                <TableRow key={i.id}>
+                  <TableCell>{i.codigo}</TableCell>
+                  <TableCell>{new Date(i.fecha).toLocaleDateString()}</TableCell>
+                  <TableCell>{i.ubicacion}</TableCell>
+                  <TableCell>{i.tipo_incidente}</TableCell>
+                  <TableCell>{i.estado}</TableCell>
+                  <TableCell align="center">
+                    <IconButton onClick={() => handleOpenDialog('view', i)}>
+                      <VisibilityIcon />
+                    </IconButton>
+                    <IconButton onClick={() => handleOpenDialog('edit', { ...i })}>
+                      <EditIcon />
+                    </IconButton>
+                    <IconButton onClick={() => alert('Eliminar no implementado')}>
+                      <DeleteIcon />
+                    </IconButton>
+                  </TableCell>
+                </TableRow>
+              ))}
+              {filtered.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={6} align="center">
+                    No se encontraron incidentes.
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </Paper>
+      )}
+
+      <Dialog open={dialogOpen} onClose={handleCloseDialog} fullWidth>
+        <DialogTitle>
+          {dialogMode === 'view'
+            ? 'Detalle del Incidente'
+            : dialogMode === 'edit'
+            ? 'Editar Incidente'
+            : 'Nuevo Incidente'}
+        </DialogTitle>
+        <DialogContent>
+          <TextField
+            fullWidth
+            margin="normal"
+            label="Código"
+            value={selected?.codigo || ''}
+            onChange={(e) => setSelected({ ...selected, codigo: e.target.value })}
+            InputProps={{ readOnly: dialogMode === 'view' }}
+          />
+          <TextField
+            fullWidth
+            margin="normal"
+            label="Fecha"
+            type="date"
+            value={selected?.fecha?.split('T')[0] || ''}
+            onChange={(e) => setSelected({ ...selected, fecha: e.target.value })}
+            InputLabelProps={{ shrink: true }}
+            InputProps={{ readOnly: dialogMode === 'view' }}
+          />
+          <TextField
+            fullWidth
+            margin="normal"
+            label="Hora"
+            type="time"
+            value={selected?.hora || ''}
+            onChange={(e) => setSelected({ ...selected, hora: e.target.value })}
+            InputProps={{ readOnly: dialogMode === 'view' }}
+          />
+          <TextField
+            fullWidth
+            margin="normal"
+            label="Ubicación"
+            value={selected?.ubicacion || ''}
+            onChange={(e) => setSelected({ ...selected, ubicacion: e.target.value })}
+            InputProps={{ readOnly: dialogMode === 'view' }}
+          />
+          <TextField
+            fullWidth
+            margin="normal"
+            label="Tipo de Incidente"
+            value={selected?.tipo_incidente || ''}
+            onChange={(e) => setSelected({ ...selected, tipo_incidente: e.target.value })}
+            InputProps={{ readOnly: dialogMode === 'view' }}
+          />
+          <TextField
+            fullWidth
+            margin="normal"
+            label="Descripción"
+            value={selected?.descripcion || ''}
+            onChange={(e) => setSelected({ ...selected, descripcion: e.target.value })}
+            multiline
+            InputProps={{ readOnly: dialogMode === 'view' }}
+          />
+          <TextField
+            fullWidth
+            margin="normal"
+            label="Estado"
+            value={selected?.estado || ''}
+            onChange={(e) => setSelected({ ...selected, estado: e.target.value })}
+            InputProps={{ readOnly: dialogMode === 'view' }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDialog}>Cerrar</Button>
+          {dialogMode !== 'view' && (
+            <Button variant="contained" onClick={() => alert('Guardar no implementado')}>
+              Guardar
+            </Button>
+          )}
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+};
+
+export default Incidentes;

--- a/frontend/src/features/incidentes/Incidentes.jsx
+++ b/frontend/src/features/incidentes/Incidentes.jsx
@@ -22,6 +22,8 @@ import EditIcon from '@mui/icons-material/Edit';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import AddIcon from '@mui/icons-material/Add';
 import axiosInstance from '../../api/axiosInstance';
+import FormCreateIncident from './components/FormCreateIncident';
+import FormEditIncident from './components/FormEditIncident';
 
 const Incidentes = () => {
   const [searchTerm, setSearchTerm] = useState('');
@@ -42,6 +44,18 @@ const Incidentes = () => {
     }
   };
 
+  const deleteIncidente = async (id) => {
+    const confirmar = window.confirm('¿Estás seguro de que quieres eliminar este incidente?');
+    if (!confirmar) return;
+
+    try {
+      await axiosInstance.delete(`/incidentes/${id}`);
+      await fetchIncidentes(); // Actualiza la lista
+    } catch (error) {
+      console.error('Error al eliminar el incidente:', error);
+    }
+  };
+
   useEffect(() => {
     fetchIncidentes();
   }, []);
@@ -55,6 +69,7 @@ const Incidentes = () => {
   const handleCloseDialog = () => {
     setDialogOpen(false);
     setSelected(null);
+    fetchIncidentes();
   };
 
   const filtered = incidentes.filter((i) =>
@@ -124,7 +139,7 @@ const Incidentes = () => {
                     <IconButton onClick={() => handleOpenDialog('edit', { ...i })}>
                       <EditIcon />
                     </IconButton>
-                    <IconButton onClick={() => alert('Eliminar no implementado')}>
+                    <IconButton onClick={() => deleteIncidente(i.id)}>
                       <DeleteIcon />
                     </IconButton>
                   </TableCell>
@@ -141,8 +156,7 @@ const Incidentes = () => {
           </Table>
         </Paper>
       )}
-
-      <Dialog open={dialogOpen} onClose={handleCloseDialog} fullWidth>
+      <Dialog open={dialogOpen} onClose={handleCloseDialog} fullWidth maxWidth="md">
         <DialogTitle>
           {dialogMode === 'view'
             ? 'Detalle del Incidente'
@@ -150,77 +164,136 @@ const Incidentes = () => {
             ? 'Editar Incidente'
             : 'Nuevo Incidente'}
         </DialogTitle>
+
         <DialogContent>
-          <TextField
-            fullWidth
-            margin="normal"
-            label="Código"
-            value={selected?.codigo || ''}
-            onChange={(e) => setSelected({ ...selected, codigo: e.target.value })}
-            InputProps={{ readOnly: dialogMode === 'view' }}
-          />
-          <TextField
-            fullWidth
-            margin="normal"
-            label="Fecha"
-            type="date"
-            value={selected?.fecha?.split('T')[0] || ''}
-            onChange={(e) => setSelected({ ...selected, fecha: e.target.value })}
-            InputLabelProps={{ shrink: true }}
-            InputProps={{ readOnly: dialogMode === 'view' }}
-          />
-          <TextField
-            fullWidth
-            margin="normal"
-            label="Hora"
-            type="time"
-            value={selected?.hora || ''}
-            onChange={(e) => setSelected({ ...selected, hora: e.target.value })}
-            InputProps={{ readOnly: dialogMode === 'view' }}
-          />
-          <TextField
-            fullWidth
-            margin="normal"
-            label="Ubicación"
-            value={selected?.ubicacion || ''}
-            onChange={(e) => setSelected({ ...selected, ubicacion: e.target.value })}
-            InputProps={{ readOnly: dialogMode === 'view' }}
-          />
-          <TextField
-            fullWidth
-            margin="normal"
-            label="Tipo de Incidente"
-            value={selected?.tipo_incidente || ''}
-            onChange={(e) => setSelected({ ...selected, tipo_incidente: e.target.value })}
-            InputProps={{ readOnly: dialogMode === 'view' }}
-          />
-          <TextField
-            fullWidth
-            margin="normal"
-            label="Descripción"
-            value={selected?.descripcion || ''}
-            onChange={(e) => setSelected({ ...selected, descripcion: e.target.value })}
-            multiline
-            InputProps={{ readOnly: dialogMode === 'view' }}
-          />
-          <TextField
-            fullWidth
-            margin="normal"
-            label="Estado"
-            value={selected?.estado || ''}
-            onChange={(e) => setSelected({ ...selected, estado: e.target.value })}
-            InputProps={{ readOnly: dialogMode === 'view' }}
-          />
+          {dialogMode === 'create' ? (
+            <FormCreateIncident onSubmit={handleCloseDialog} />
+          ) : dialogMode === 'edit' ? (
+            <FormEditIncident
+              open={dialogOpen}
+              onClose={handleCloseDialog}
+              incidente={selected}
+            />
+          ) : (
+            <>
+              <TextField
+                fullWidth
+                margin="normal"
+                label="Código"
+                value={selected?.codigo || ''}
+                onChange={(e) => setSelected({ ...selected, codigo: e.target.value })}
+                InputProps={{ readOnly: dialogMode === 'view' }}
+              />
+              <TextField
+                fullWidth
+                margin="normal"
+                label="Fecha"
+                type="date"
+                value={selected?.fecha?.split('T')[0] || ''}
+                onChange={(e) => setSelected({ ...selected, fecha: e.target.value })}
+                InputLabelProps={{ shrink: true }}
+                InputProps={{ readOnly: dialogMode === 'view' }}
+              />
+              <TextField
+                fullWidth
+                margin="normal"
+                label="Hora"
+                type="time"
+                value={selected?.hora || ''}
+                onChange={(e) => setSelected({ ...selected, hora: e.target.value })}
+                InputProps={{ readOnly: dialogMode === 'view' }}
+              />
+              <TextField
+                fullWidth
+                margin="normal"
+                label="Ubicación"
+                value={selected?.ubicacion || ''}
+                onChange={(e) => setSelected({ ...selected, ubicacion: e.target.value })}
+                InputProps={{ readOnly: dialogMode === 'view' }}
+              />
+              <TextField
+                fullWidth
+                margin="normal"
+                label="Tipo de Incidente"
+                value={selected?.tipo_incidente || ''}
+                onChange={(e) => setSelected({ ...selected, tipo_incidente: e.target.value })}
+                InputProps={{ readOnly: dialogMode === 'view' }}
+              />
+              <TextField
+                fullWidth
+                margin="normal"
+                label="Descripción"
+                value={selected?.descripcion || ''}
+                onChange={(e) => setSelected({ ...selected, descripcion: e.target.value })}
+                multiline
+                InputProps={{ readOnly: dialogMode === 'view' }}
+              />
+              <TextField
+                fullWidth
+                margin="normal"
+                label="Estado"
+                value={selected?.estado || ''}
+                onChange={(e) => setSelected({ ...selected, estado: e.target.value })}
+                InputProps={{ readOnly: dialogMode === 'view' }}
+              />
+
+              {dialogMode === 'view' && selected?.detalle_robots?.length > 0 && (
+                <Box mt={3}>
+                  <Typography variant="h6" gutterBottom>
+                    Robots Involucrados
+                  </Typography>
+                  {selected.detalle_robots.map((robot, index) => {
+                    let bgColor;
+                    switch (robot.estado) {
+                      case 'en_reparacion':
+                        bgColor = '#fbc02d'; // amarillo
+                        break;
+                      case 'fuera_servicio':
+                        bgColor = '#e53935'; // rojo
+                        break;
+                      case 'operativo':
+                        bgColor = '#43a047'; // verde
+                        break;
+                      default:
+                        bgColor = '#757575';
+                    }
+
+                    return (
+                      <Box
+                        key={index}
+                        sx={{
+                          backgroundColor: bgColor,
+                          color: '#fff',
+                          borderRadius: 2,
+                          padding: 2,
+                          mb: 2,
+                        }}
+                      >
+                        <Typography variant="body1">
+                          <strong>ID:</strong> {robot.id}
+                        </Typography>
+                        <Typography variant="body1">
+                          <strong>Estado:</strong> {robot.estado.replace('_', ' ')}
+                        </Typography>
+                      </Box>
+                    );
+                  })}
+                </Box>
+              )}
+            </>
+          )}
         </DialogContent>
+
         <DialogActions>
           <Button onClick={handleCloseDialog}>Cerrar</Button>
-          {dialogMode !== 'view' && (
+          {dialogMode === 'edit' && (
             <Button variant="contained" onClick={() => alert('Guardar no implementado')}>
               Guardar
             </Button>
           )}
         </DialogActions>
       </Dialog>
+
     </Box>
   );
 };

--- a/frontend/src/features/incidentes/components/FormCreateIncident.jsx
+++ b/frontend/src/features/incidentes/components/FormCreateIncident.jsx
@@ -1,0 +1,164 @@
+// components/FormularioNuevoIncidente.jsx
+import { useState, useEffect } from 'react';
+import {
+  Box, TextField, MenuItem, Typography, Button, Table, TableBody, TableCell,
+  TableHead, TableRow, Paper, Select, InputLabel, FormControl
+} from '@mui/material';
+import axiosInstance from '../../../api/axiosInstance';
+import { useSelector } from 'react-redux';
+
+const ESTADOS_ROBOT = ['operativo', 'en_reparacion', 'fuera_servicio'];
+
+const FormCreateIncident = ({ onSubmit }) => {
+  const user = useSelector(state => state.auth.user);
+  const [robots, setRobots] = useState([]);
+  const [incidente, setIncidente] = useState({
+    fecha: new Date().toISOString().split('T')[0],
+    hora: new Date().toTimeString().slice(0, 5),
+    ubicacion: '',
+    tipo_incidente: 'mecanico',
+    descripcion: '',
+    estado: 'creado',
+    detalle_robots: []
+  });
+
+  useEffect(() => {
+    axiosInstance.get('/robots')
+      .then(res => setRobots(res.data))
+      .catch(err => console.error('Error al cargar robots', err));
+  }, []);
+
+  const agregarRobot = (robot) => {
+    if (!incidente.detalle_robots.some(r => r.id === robot.id)) {
+      setIncidente({
+        ...incidente,
+        detalle_robots: [...incidente.detalle_robots, { id: robot.id, estado: 'operativo' }]
+      });
+    }
+  };
+
+  const actualizarEstadoRobot = (index, estado) => {
+    const nuevos = [...incidente.detalle_robots];
+    nuevos[index].estado = estado;
+    setIncidente({ ...incidente, detalle_robots: nuevos });
+  };
+
+  const handleSubmit = async () => {
+    const confirmar = window.confirm('¿Estás seguro de que quieres añadir este incidente?');
+    if (!confirmar) return;
+    try {
+      await axiosInstance.post('/incidentes', {
+        ...incidente,
+        creado_por: user.id
+      });
+      onSubmit?.();
+    } catch (err) {
+      console.error('Error al crear incidente', err);
+    }
+  };
+
+  return (
+    <Box>
+      <TextField
+        fullWidth margin="normal" label="Ubicación"
+        value={incidente.ubicacion}
+        onChange={e => setIncidente({ ...incidente, ubicacion: e.target.value })}
+      />
+      <TextField
+        fullWidth margin="normal" label="Descripción"
+        value={incidente.descripcion}
+        onChange={e => setIncidente({ ...incidente, descripcion: e.target.value })}
+        multiline
+      />
+      <TextField
+        select fullWidth margin="normal" label="Tipo de Incidente"
+        value={incidente.tipo_incidente}
+        onChange={e => setIncidente({ ...incidente, tipo_incidente: e.target.value })}
+      >
+        {['mecanico', 'colision', 'software'].map(tipo => (
+          <MenuItem key={tipo} value={tipo}>{tipo}</MenuItem>
+        ))}
+      </TextField>
+      <TextField
+        select fullWidth margin="normal" label="Estado"
+        value={incidente.estado}
+        onChange={e => setIncidente({ ...incidente, estado: e.target.value })}
+      >
+        {['creado', 'cerrado'].map(estado => (
+          <MenuItem key={estado} value={estado}>{estado}</MenuItem>
+        ))}
+      </TextField>
+      <TextField
+        fullWidth margin="normal" label="Fecha" type="date"
+        value={incidente.fecha}
+        onChange={e => setIncidente({ ...incidente, fecha: e.target.value })}
+        InputLabelProps={{ shrink: true }}
+      />
+      <TextField
+        fullWidth margin="normal" label="Hora" type="time"
+        value={incidente.hora}
+        onChange={e => setIncidente({ ...incidente, hora: e.target.value })}
+      />
+
+      <Typography variant="h6" mt={3}>Robots disponibles</Typography>
+      <Paper sx={{ maxHeight: 200, overflow: 'auto' }}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>ID</TableCell>
+              <TableCell>Nombre</TableCell>
+              <TableCell>Modelo</TableCell>
+              <TableCell>Acción</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {robots.map(robot => (
+              <TableRow key={robot.id}>
+                <TableCell>{robot.id}</TableCell>
+                <TableCell>{robot.nombre}</TableCell>
+                <TableCell>{robot.modelo}</TableCell>
+                <TableCell>
+                  <Button onClick={() => agregarRobot(robot)}>Agregar</Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Paper>
+
+      {incidente.detalle_robots.length > 0 && (
+        <>
+          <Typography variant="h6" mt={3}>Robots seleccionados</Typography>
+          {incidente.detalle_robots.map((r, idx) => (
+            <TableRow key={r.id}>
+              <TableCell>{r.id}</TableCell>
+              <TableCell>
+                <FormControl fullWidth size="small">
+                  <InputLabel>Estado</InputLabel>
+                  <Select
+                    value={r.estado}
+                    label="Estado"
+                    onChange={e => actualizarEstadoRobot(idx, e.target.value)}
+                  >
+                    {ESTADOS_ROBOT.map(est => (
+                      <MenuItem key={est} value={est}>{est}</MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              </TableCell>
+            </TableRow>
+          ))}
+
+        </>
+      )}
+
+      <Box mt={3}>
+        <Button variant="contained" onClick={handleSubmit}>
+          Crear Incidente
+        </Button>
+      </Box>
+    </Box>
+  );
+};
+
+export default FormCreateIncident;

--- a/frontend/src/features/incidentes/components/FormEditIncident.jsx
+++ b/frontend/src/features/incidentes/components/FormEditIncident.jsx
@@ -1,0 +1,191 @@
+import {
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogActions,
+    Button,
+    TextField,
+    MenuItem,
+    Typography,
+    Box,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableRow,
+    Select,
+    InputLabel,
+    FormControl,
+  } from '@mui/material';
+  import { useEffect, useState } from 'react';
+  import axiosInstance from '../../../api/axiosInstance';
+  
+  const FormEditIncident = ({ open, onClose, incidente }) => {
+    const [formData, setFormData] = useState(null);
+    const [robotsDisponibles, setRobotsDisponibles] = useState([]);
+  
+    useEffect(() => {
+      if (incidente) {
+        // Clonar incidente recibido
+        setFormData({
+          ...incidente,
+          detalle_robots: incidente.detalle_robots || [],
+        });
+      }
+    }, [incidente]);
+  
+    useEffect(() => {
+      const fetchRobots = async () => {
+        try {
+          const res = await axiosInstance.get('/robots');
+          setRobotsDisponibles(res.data);
+        } catch (error) {
+          console.error('Error al obtener robots:', error);
+        }
+      };
+  
+      fetchRobots();
+    }, []);
+  
+    const handleFieldChange = (field, value) => {
+      setFormData((prev) => ({ ...prev, [field]: value }));
+    };
+  
+    const handleRobotStateChange = (index, estado) => {
+      const updated = [...formData.detalle_robots];
+      updated[index].estado = estado;
+      setFormData((prev) => ({ ...prev, detalle_robots: updated }));
+    };
+  
+    const handleSubmit = async () => {
+      const confirmar = window.confirm('¿Estás seguro de que quieres editar este incidente?');
+      if (!confirmar) return;
+      try {
+        await axiosInstance.put(`/incidentes/${formData.id}`, {
+          ...formData,
+          creado_por: undefined // aseguramos que no se actualiza eso
+        });
+        onClose(); // cierra y permite recargar
+      } catch (err) {
+        console.error('Error al actualizar incidente:', err);
+      }
+    };
+  
+    if (!formData) return null;
+  
+    return (
+      <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
+        <DialogTitle>Editar Incidente</DialogTitle>
+        <DialogContent>
+          <TextField
+            fullWidth
+            margin="normal"
+            label="Código"
+            value={formData.codigo || ''}
+            onChange={(e) => handleFieldChange('codigo', e.target.value)}
+          />
+          <TextField
+            fullWidth
+            margin="normal"
+            type="date"
+            label="Fecha"
+            InputLabelProps={{ shrink: true }}
+            value={formData.fecha?.split('T')[0] || ''}
+            onChange={(e) => handleFieldChange('fecha', e.target.value)}
+          />
+          <TextField
+            fullWidth
+            margin="normal"
+            type="time"
+            label="Hora"
+            value={formData.hora || ''}
+            onChange={(e) => handleFieldChange('hora', e.target.value)}
+          />
+          <TextField
+            fullWidth
+            margin="normal"
+            label="Ubicación"
+            value={formData.ubicacion || ''}
+            onChange={(e) => handleFieldChange('ubicacion', e.target.value)}
+          />
+          <TextField
+            select
+            fullWidth
+            margin="normal"
+            label="Tipo de Incidente"
+            value={formData.tipo_incidente || ''}
+            onChange={(e) => handleFieldChange('tipo_incidente', e.target.value)}
+          >
+            <MenuItem value="mecanico">Mecánico</MenuItem>
+            <MenuItem value="colision">Colisión</MenuItem>
+            <MenuItem value="software">Software</MenuItem>
+          </TextField>
+          <TextField
+            fullWidth
+            margin="normal"
+            label="Descripción"
+            value={formData.descripcion || ''}
+            onChange={(e) => handleFieldChange('descripcion', e.target.value)}
+            multiline
+          />
+          <TextField
+            select
+            fullWidth
+            margin="normal"
+            label="Estado"
+            value={formData.estado || ''}
+            onChange={(e) => handleFieldChange('estado', e.target.value)}
+          >
+            <MenuItem value="creado">Creado</MenuItem>
+            <MenuItem value="cerrado">Cerrado</MenuItem>
+          </TextField>
+  
+          {formData.detalle_robots.length > 0 && (
+            <Box mt={3}>
+              <Typography variant="h6" gutterBottom>
+                Robots Involucrados
+              </Typography>
+              <Table>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>ID</TableCell>
+                    <TableCell>Estado</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {formData.detalle_robots.map((robot, index) => (
+                    <TableRow key={index}>
+                      <TableCell>{robot.id}</TableCell>
+                      <TableCell>
+                        <FormControl fullWidth>
+                          <InputLabel>Estado</InputLabel>
+                          <Select
+                            value={robot.estado}
+                            label="Estado"
+                            onChange={(e) => handleRobotStateChange(index, e.target.value)}
+                          >
+                            <MenuItem value="operativo">Operativo</MenuItem>
+                            <MenuItem value="en_reparacion">En reparación</MenuItem>
+                            <MenuItem value="fuera_servicio">Fuera de servicio</MenuItem>
+                          </Select>
+                        </FormControl>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </Box>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose}>Cancelar</Button>
+          <Button variant="contained" onClick={handleSubmit}>
+            Guardar Cambios
+          </Button>
+        </DialogActions>
+      </Dialog>
+    );
+  };
+  
+  export default FormEditIncident;
+  


### PR DESCRIPTION
Se añaden formularios para crear, editar, eliminar y ver los detalles de los incidentes.


Crear y Editar (mismo frontend se usa distinta api):
![Captura de pantalla 2025-05-12 a la(s) 20 14 14](https://github.com/user-attachments/assets/9a0a78b0-622e-421e-8ecd-3dabf43050dd)

Eliminar: Se confirma si se quiere eliminar
![Captura de pantalla 2025-05-12 a la(s) 20 15 19](https://github.com/user-attachments/assets/a65155e1-7caa-4028-8717-4a98157132a6)

Detalles a incidente:
![Captura de pantalla 2025-05-12 a la(s) 20 15 49](https://github.com/user-attachments/assets/fc86244a-5514-4910-9b9d-59bea41d02c7)


Como probar:
- ejecutar el frontend y revisar que los flujos se lleven a cabo en el backend sin problemas. OJO: no asustarse con los codigos 304 (304: no ha cambiado la data por ende no se hace la consulta).
- ejecutar el backend para ver que las peticiones se ejecute de forma correcta